### PR TITLE
Updated $fillable & $guarded PHPDoc variable types

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -717,7 +717,7 @@ When assigning JSON columns, each column's mass assignable key must be specified
     /**
      * The attributes that are mass assignable.
      *
-     * @var array
+     * @var String[]
      */
     protected $fillable = [
         'options->enabled',
@@ -731,7 +731,7 @@ If you would like to make all of your attributes mass assignable, you may define
     /**
      * The attributes that aren't mass assignable.
      *
-     * @var array
+     * @var String[]
      */
     protected $guarded = [];
 


### PR DESCRIPTION
Changed from ````array```` to ````String[]```` as per the underlying [concern](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php)